### PR TITLE
The juan and only99 patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ If you would like to get involved in a specific working group, check out that wo
 
 ## Mailing List
 
-All SIG related communications are conducted through the devops-mutulization@finos.org mailing list. Email devops-mutulization@finos.org with questions or suggestions for collaboration use cases.
+All SIG related communications are conducted through the devops-mutulization@finos.org mailing list. Email devops-automation@finos.org with questions or suggestions for collaboration use cases.
 
-Subscribe to the DevOps Automation mailing list by sending an email to [devops-mutulization+subscribe@finos.org](mailto:devops-mutulization+subscribe@finos.org?subject=Subscribe).
+Subscribe to the DevOps Automation mailing list by sending an email to [devops-automation+subscribe@finos.org](mailto:devops-automation+subscribe@finos.org?subject=Subscribe).
 
 ## SIG Discussions
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you would like to get involved in a specific working group, check out that wo
 
 ## Mailing List
 
-All SIG related communications are conducted through the devops-mutulization@finos.org mailing list. Email devops-automation@finos.org with questions or suggestions for collaboration use cases.
+All SIG related communications are conducted through the devops-automation@finos.org mailing list. Email devops-automation@finos.org with questions or suggestions for collaboration use cases.
 
 Subscribe to the DevOps Automation mailing list by sending an email to [devops-automation+subscribe@finos.org](mailto:devops-automation+subscribe@finos.org?subject=Subscribe).
 


### PR DESCRIPTION
Mailing list was renamed to devops-automation@finos.org sometime ago. While there is a redirect in place we should update the name to be congruent with the name of the sig. 